### PR TITLE
Add theme switcher with static export support

### DIFF
--- a/src/server/export.go
+++ b/src/server/export.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"html/template"
@@ -10,8 +11,8 @@ import (
 	"os"
 	pathpkg "path"
 	"path/filepath"
+	"regexp"
 	"strings"
-	ttemplate "text/template"
 
 	articlepkg "github.com/sbraveyoung/gobog/src/article"
 	"github.com/sbraveyoung/gobog/src/blog"
@@ -70,13 +71,176 @@ func Export(outDir string) error {
 	if err := writeCNAME(outDir); err != nil {
 		return err
 	}
+	// Per-theme exports so the switcher button works on a static host.
+	// Each non-default theme lands at outDir/__themes/<name>/ with all
+	// internal absolute paths rewritten to live under that prefix.
+	if err := exportAllThemes(outDir); err != nil {
+		return err
+	}
 
 	logs.Info("export complete:", outDir)
 	return nil
 }
 
+// exportAllThemes renders the whole site once per available theme into
+// outDir/__themes/<name>/, then writes the manifest + theme-switcher script
+// at the root so the front-end button works offline. The default theme keeps
+// its position at outDir/ — no duplicate copy.
+func exportAllThemes(outDir string) error {
+	themes := availableThemes()
+	defaultName := filepath.Base(filepath.Clean(config.C.Blog.Theme))
+	parent := filepath.Dir(filepath.Clean(config.C.Blog.Theme))
+
+	// Root manifest + switcher script. Browsers fetch these from / no matter
+	// which theme directory the visitor is currently viewing.
+	if err := writeThemeManifest(filepath.Join(outDir, "__themes.json"), themes, defaultName, ""); err != nil {
+		return err
+	}
+	if err := writeFile(filepath.Join(outDir, "__theme-switcher.js"), []byte(themeSwitcherJS)); err != nil {
+		return err
+	}
+
+	// Only one theme available? Nothing more to do — the switcher itself
+	// already gates on `themes.length >= 2`.
+	if len(themes) < 2 {
+		return nil
+	}
+
+	saved := config.C.Blog.Theme
+	defer func() { config.C.Blog.Theme = saved }()
+
+	for _, name := range themes {
+		if name == defaultName {
+			continue
+		}
+		themeDir := filepath.Join(parent, name)
+		themeOut := filepath.Join(outDir, "__themes", name)
+		config.C.Blog.Theme = themeDir
+
+		if err := exportIndex(themeOut); err != nil {
+			return fmt.Errorf("export theme %q index: %w", name, err)
+		}
+		if err := exportPages(themeOut); err != nil {
+			return fmt.Errorf("export theme %q pages: %w", name, err)
+		}
+		if err := exportPosts(themeOut); err != nil {
+			return fmt.Errorf("export theme %q posts: %w", name, err)
+		}
+		if err := exportTags(themeOut); err != nil {
+			return fmt.Errorf("export theme %q tags: %w", name, err)
+		}
+		if err := exportNotFound(themeOut); err != nil {
+			return fmt.Errorf("export theme %q 404: %w", name, err)
+		}
+
+		// Copy this theme's own CSS/JS so the prefixed HTML can reach them.
+		for _, sub := range []string{"css", "js"} {
+			src := filepath.Join(themeDir, sub)
+			if fi, err := os.Stat(src); err == nil && fi.IsDir() {
+				if err := copyTree(src, filepath.Join(themeOut, sub)); err != nil {
+					return fmt.Errorf("copy theme %q %s: %w", name, sub, err)
+				}
+			}
+		}
+		// Images are theme-independent — copy from the already-exported root
+		// tree so the prefixed <img src="/__themes/<name>/image/..."> resolves.
+		rootImage := filepath.Join(outDir, "image")
+		if fi, err := os.Stat(rootImage); err == nil && fi.IsDir() {
+			if err := copyTree(rootImage, filepath.Join(themeOut, "image")); err != nil {
+				return fmt.Errorf("copy images for theme %q: %w", name, err)
+			}
+		}
+
+		// Each theme subdir advertises its own manifest so the switcher
+		// renders "active" correctly even when JS detection lags.
+		if err := writeThemeManifest(filepath.Join(themeOut, "__themes.json"), themes, defaultName, name); err != nil {
+			return err
+		}
+		if err := writeFile(filepath.Join(themeOut, "__theme-switcher.js"), []byte(themeSwitcherJS)); err != nil {
+			return err
+		}
+
+		if err := rewriteThemePaths(themeOut, "/__themes/"+name); err != nil {
+			return fmt.Errorf("rewrite theme %q paths: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func writeThemeManifest(path string, themes []string, defaultName, current string) error {
+	payload := map[string]interface{}{
+		"themes":  themes,
+		"default": defaultName,
+		"current": current,
+		"static":  true,
+	}
+	b, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writeFile(path, b)
+}
+
+// pathAttrRE matches href / src / action attributes pointing at root-anchored
+// paths. The capture is greedy on attribute value contents so query strings
+// and fragments come along for the rewrite.
+var pathAttrRE = regexp.MustCompile(`(href|src|action)="(/[^"]*)"`)
+
+// pathsThatStayAtRoot — internal endpoints the rewrite must NOT relocate so
+// the static switcher and its manifest always resolve from the document root
+// regardless of which theme subtree the visitor is in.
+var pathsThatStayAtRoot = []string{
+	"/__themes/",
+	"/__themes.json",
+	"/__theme-switcher.js",
+}
+
+func rewritePathsInHTML(content, prefix string) string {
+	if prefix == "" {
+		return content
+	}
+	return pathAttrRE.ReplaceAllStringFunc(content, func(m string) string {
+		eq := strings.Index(m, `="`)
+		if eq < 0 {
+			return m
+		}
+		attr := m[:eq]
+		url := m[eq+2 : len(m)-1]
+		if strings.HasPrefix(url, "//") {
+			return m
+		}
+		for _, keep := range pathsThatStayAtRoot {
+			if url == strings.TrimSuffix(keep, "/") || url == keep || strings.HasPrefix(url, keep) {
+				return m
+			}
+		}
+		return attr + `="` + prefix + url + `"`
+	})
+}
+
+func rewriteThemePaths(dir, prefix string) error {
+	return filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		ext := strings.ToLower(filepath.Ext(p))
+		if ext != ".html" && ext != ".xml" {
+			return nil
+		}
+		b, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		out := rewritePathsInHTML(string(b), prefix)
+		if out == string(b) {
+			return nil
+		}
+		return os.WriteFile(p, []byte(out), 0o644)
+	})
+}
+
 func exportIndex(outDir string) error {
-	t, err := template.ParseFiles(config.C.Blog.Theme + "/index.html")
+	t, err := parseHTMLTemplate(config.C.Blog.Theme + "/index.html")
 	if err != nil {
 		return fmt.Errorf("parse index template: %w", err)
 	}
@@ -161,9 +325,9 @@ func exportPosts(outDir string) error {
 func loadGroupTemplate() (*template.Template, error) {
 	groupPath := config.C.Blog.Theme + "/group.html"
 	if _, err := os.Stat(groupPath); err == nil {
-		return template.ParseFiles(groupPath)
+		return parseHTMLTemplate(groupPath)
 	}
-	return template.ParseFiles(config.C.Blog.Theme + "/index.html")
+	return parseHTMLTemplate(config.C.Blog.Theme + "/index.html")
 }
 
 // withoutPrivate returns a shallow copy of list with private articles
@@ -267,7 +431,7 @@ func exportNotFound(outDir string) error {
 }
 
 func executePostTemplate(a *articlepkg.Article, html string) ([]byte, error) {
-	t, err := ttemplate.ParseFiles(config.C.Blog.Theme + "/post.html")
+	t, err := parseTextTemplate(config.C.Blog.Theme + "/post.html")
 	if err != nil {
 		return nil, err
 	}

--- a/src/server/render.go
+++ b/src/server/render.go
@@ -283,12 +283,12 @@ type indexView struct {
 
 	Tag      string
 	Group    string
-	Articles articlepkg.Articles
+	Articles []*postCardView
 	Year     int
 	Now      time.Time
-	Feature  *articlepkg.Article
-	Digest   articlepkg.Articles
-	Rest     articlepkg.Articles
+	Feature  *postCardView
+	Digest   []*postCardView
+	Rest     []*postCardView
 	AllTags  []TagCount
 }
 
@@ -299,16 +299,58 @@ type TagCount struct {
 	Count int
 }
 
+// postCardView wraps an *Article for the flat post-feed views that
+// letter / tufte / press templates iterate over. The raw Article only
+// exposes Is{Pinned,Private,AI} methods + a `Cover` raw string, but the
+// new themes use field-style `.Pinned`, `.AI`, `.CoverURL`, etc. The
+// wrapper keeps the article's own fields/methods reachable via embedding
+// so existing accessors like `.Title`, `.Summary`, `.CreateTime`,
+// `.ReadingTimeMin` continue to work unchanged.
+//
+// ViewCount stays at 0 — the view-count subsystem was retired but
+// some themes still reference `{{ if .ViewCount }}`, and a missing
+// field would crash the renderer instead of just being falsy.
+type postCardView struct {
+	*articlepkg.Article
+	Pinned    bool
+	Private   bool
+	AI        bool
+	AILabel   string
+	CoverURL  string
+	ViewCount int
+}
+
+func newPostCardView(a *articlepkg.Article) *postCardView {
+	return &postCardView{
+		Article:  a,
+		Pinned:   a.IsPinned(),
+		Private:  a.IsPrivate(),
+		AI:       a.IsAI(),
+		AILabel:  a.AILabel(),
+		CoverURL: coverURL(a.Cover),
+	}
+}
+
+func newPostCardViews(list articlepkg.Articles) []*postCardView {
+	out := make([]*postCardView, 0, len(list))
+	for _, a := range list {
+		out = append(out, newPostCardView(a))
+	}
+	return out
+}
+
 func newIndexView(groups articlepkg.Articles) indexView {
 	site := newSiteMeta()
 	posts := flattenPosts(groups)
 	now := time.Now()
 
-	var feature *articlepkg.Article
-	var digest, rest articlepkg.Articles
-	if len(posts) > 0 {
-		feature = posts[0]
-		tail := posts[1:]
+	cards := newPostCardViews(posts)
+
+	var feature *postCardView
+	var digest, rest []*postCardView
+	if len(cards) > 0 {
+		feature = cards[0]
+		tail := cards[1:]
 		n := 3
 		if len(tail) < n {
 			n = len(tail)
@@ -326,7 +368,7 @@ func newIndexView(groups articlepkg.Articles) indexView {
 	return indexView{
 		Site:     site,
 		Groups:   groups,
-		Articles: posts,
+		Articles: cards,
 		Year:     now.Year(),
 		Now:      now,
 		Feature:  feature,

--- a/src/server/render.go
+++ b/src/server/render.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -271,13 +272,93 @@ func newSiteMeta() SiteMeta {
 
 // indexView is what the home template receives. SiteMeta lives under .Site so
 // templates can disambiguate from per-page metadata (group titles, etc.).
+// Several fields below (Tag/Group/Articles/Year/Now/Feature/Digest/Rest/AllTags)
+// exist purely so the newer themes (letter / tufte / press) compile against
+// the same view as the minimal/ocean/sepia themes — without them, switching
+// to a "design-canvas" theme would crash the renderer with
+// `can't evaluate field <name> in type server.indexView`.
 type indexView struct {
 	Site   SiteMeta
 	Groups articlepkg.Articles
+
+	Tag      string
+	Group    string
+	Articles articlepkg.Articles
+	Year     int
+	Now      time.Time
+	Feature  *articlepkg.Article
+	Digest   articlepkg.Articles
+	Rest     articlepkg.Articles
+	AllTags  []TagCount
+}
+
+// TagCount is the {Name, Count} pair the tufte theme iterates over for its
+// tag cloud. Exposed by name so templates can keep `{{.Name}} {{.Count}}`.
+type TagCount struct {
+	Name  string
+	Count int
 }
 
 func newIndexView(groups articlepkg.Articles) indexView {
-	return indexView{Site: newSiteMeta(), Groups: groups}
+	site := newSiteMeta()
+	posts := flattenPosts(groups)
+	now := time.Now()
+
+	var feature *articlepkg.Article
+	var digest, rest articlepkg.Articles
+	if len(posts) > 0 {
+		feature = posts[0]
+		tail := posts[1:]
+		n := 3
+		if len(tail) < n {
+			n = len(tail)
+		}
+		digest = tail[:n]
+		rest = tail[n:]
+	}
+
+	tags := blog.Blog.Tags()
+	allTags := make([]TagCount, 0, len(tags))
+	for _, t := range tags {
+		allTags = append(allTags, TagCount{Name: t, Count: len(blog.Blog.PostsByTag(t))})
+	}
+
+	return indexView{
+		Site:     site,
+		Groups:   groups,
+		Articles: posts,
+		Year:     now.Year(),
+		Now:      now,
+		Feature:  feature,
+		Digest:   digest,
+		Rest:     rest,
+		AllTags:  allTags,
+	}
+}
+
+// flattenPosts walks a group tree and returns every leaf article, sorted by
+// pinned-first then create_time descending. Themes that present a flat
+// "article feed" (letter / tufte / press) iterate over this.
+func flattenPosts(list articlepkg.Articles) articlepkg.Articles {
+	var out articlepkg.Articles
+	var walk func(articlepkg.Articles)
+	walk = func(items articlepkg.Articles) {
+		for _, a := range items {
+			if len(a.SubArticle) == 0 {
+				out = append(out, a)
+			} else {
+				walk(a.SubArticle)
+			}
+		}
+	}
+	walk(list)
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].IsPinned() != out[j].IsPinned() {
+			return out[i].IsPinned()
+		}
+		return out[i].CreateTime > out[j].CreateTime
+	})
+	return out
 }
 
 // groupView is what group.html receives for a group landing page (a series,
@@ -318,6 +399,7 @@ type articleView struct {
 	AI          bool
 	AILabel     string
 	CoverURL    string
+	Year        int
 }
 
 func newArticleView(a *articlepkg.Article, parse, domain string) articleView {
@@ -342,6 +424,7 @@ func newArticleView(a *articlepkg.Article, parse, domain string) articleView {
 		AI:          a.IsAI(),
 		AILabel:     a.AILabel(),
 		CoverURL:    coverURL(a.Cover),
+		Year:        site.Year,
 	}
 }
 

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	ttemplate "text/template"
 	"time"
 
 	articlepkg "github.com/sbraveyoung/gobog/src/article"
@@ -132,7 +131,7 @@ func logMiddle(f func(w http.ResponseWriter, r *http.Request)) func(w http.Respo
 
 func rootHandler(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path == "/" {
-		t, err := template.ParseFiles(themeFor(r) + "/index.html")
+		t, err := parseHTMLTemplate(themeFor(r) + "/index.html")
 		if err != nil {
 			logs.Error("parse index template:", err)
 			w.WriteHeader(http.StatusInternalServerError)
@@ -222,7 +221,7 @@ func renderPost(w http.ResponseWriter, r *http.Request, article *articlepkg.Arti
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	t, err := ttemplate.ParseFiles(themeFor(r) + "/post.html")
+	t, err := parseTextTemplate(themeFor(r) + "/post.html")
 	if err != nil {
 		logs.Warn("parse post template:", err)
 		w.WriteHeader(http.StatusInternalServerError)
@@ -245,7 +244,7 @@ func renderGroup(w http.ResponseWriter, r *http.Request, group *articlepkg.Artic
 	if _, err := os.Stat(tplPath); os.IsNotExist(err) {
 		tplPath = theme + "/index.html"
 	}
-	t, err := template.ParseFiles(tplPath)
+	t, err := parseHTMLTemplate(tplPath)
 	if err != nil {
 		logs.Warn("parse group template:", err)
 		w.WriteHeader(http.StatusInternalServerError)
@@ -334,7 +333,7 @@ func searchPosts(query string) articlepkg.Articles {
 }
 
 func writeSyntheticPost(w http.ResponseWriter, r *http.Request, title, bodyHTML string) {
-	t, err := ttemplate.ParseFiles(themeFor(r) + "/post.html")
+	t, err := parseTextTemplate(themeFor(r) + "/post.html")
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
@@ -348,7 +347,7 @@ func writeSyntheticPost(w http.ResponseWriter, r *http.Request, title, bodyHTML 
 
 func notFound(w http.ResponseWriter, r *http.Request) {
 	logs.Warn("404:", r.URL.Path)
-	t, err := ttemplate.ParseFiles(themeFor(r) + "/post.html")
+	t, err := parseTextTemplate(themeFor(r) + "/post.html")
 	if err == nil {
 		w.WriteHeader(http.StatusNotFound)
 		a := &articlepkg.Article{}

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -118,6 +118,8 @@ func (s *Server) newHandler() http.Handler {
 	mux.HandleFunc("/bing_img", logMiddle(bingImgHandler))
 	mux.HandleFunc("/snippet", logMiddle(snippetHandler))
 	mux.HandleFunc("/snippet/", logMiddle(snippetHandler))
+	mux.HandleFunc("/__themes.json", logMiddle(themesJSONHandler))
+	mux.HandleFunc("/__theme-switcher.js", themeSwitcherJSHandler)
 	return mux
 }
 
@@ -130,7 +132,7 @@ func logMiddle(f func(w http.ResponseWriter, r *http.Request)) func(w http.Respo
 
 func rootHandler(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path == "/" {
-		t, err := template.ParseFiles(config.C.Blog.Theme + "/index.html")
+		t, err := template.ParseFiles(themeFor(r) + "/index.html")
 		if err != nil {
 			logs.Error("parse index template:", err)
 			w.WriteHeader(http.StatusInternalServerError)
@@ -168,7 +170,7 @@ func postHandler(w http.ResponseWriter, r *http.Request) {
 	if len(matched.SubArticle) == 0 {
 		renderPost(w, r, matched)
 	} else {
-		renderGroup(w, matched, matched.SubArticle)
+		renderGroup(w, r, matched, matched.SubArticle)
 	}
 }
 
@@ -220,7 +222,7 @@ func renderPost(w http.ResponseWriter, r *http.Request, article *articlepkg.Arti
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	t, err := ttemplate.ParseFiles(config.C.Blog.Theme + "/post.html")
+	t, err := ttemplate.ParseFiles(themeFor(r) + "/post.html")
 	if err != nil {
 		logs.Warn("parse post template:", err)
 		w.WriteHeader(http.StatusInternalServerError)
@@ -237,10 +239,11 @@ func renderPost(w http.ResponseWriter, r *http.Request, article *articlepkg.Arti
 // layout) keep working. Group pages get a richer view: title (group name),
 // breadcrumb, sub-articles list — index.html only ever sees the top-level
 // groups, so reusing it for a sub-group landing was always a half-fit.
-func renderGroup(w http.ResponseWriter, group *articlepkg.Article, list articlepkg.Articles) {
-	tplPath := config.C.Blog.Theme + "/group.html"
+func renderGroup(w http.ResponseWriter, r *http.Request, group *articlepkg.Article, list articlepkg.Articles) {
+	theme := themeFor(r)
+	tplPath := theme + "/group.html"
 	if _, err := os.Stat(tplPath); os.IsNotExist(err) {
-		tplPath = config.C.Blog.Theme + "/index.html"
+		tplPath = theme + "/index.html"
 	}
 	t, err := template.ParseFiles(tplPath)
 	if err != nil {
@@ -266,7 +269,7 @@ func tagHandler(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintf(&sb, "<li><a href=\"/tag/%s\">%s</a></li>", t, t)
 		}
 		sb.WriteString("</ul>")
-		writeSyntheticPost(w, "Tags", sb.String())
+		writeSyntheticPost(w, r, "Tags", sb.String())
 		return
 	}
 	posts := blog.Blog.PostsByTag(tag)
@@ -277,24 +280,24 @@ func tagHandler(w http.ResponseWriter, r *http.Request) {
 	synthetic := &articlepkg.Article{}
 	synthetic.Title = "#" + tag
 	synthetic.URL = "/tag/" + tag
-	renderGroup(w, synthetic, posts)
+	renderGroup(w, r, synthetic, posts)
 }
 
 func searchHandler(w http.ResponseWriter, r *http.Request) {
 	q := strings.TrimSpace(r.URL.Query().Get("query"))
 	if q == "" {
-		writeSyntheticPost(w, "Search", `<form method="get" action="/search"><input name="query" placeholder="search" autofocus/><button>Go</button></form>`)
+		writeSyntheticPost(w, r, "Search", `<form method="get" action="/search"><input name="query" placeholder="search" autofocus/><button>Go</button></form>`)
 		return
 	}
 	results := searchPosts(q)
 	if len(results) == 0 {
-		writeSyntheticPost(w, "Search: "+q, "<p>No matching posts.</p>")
+		writeSyntheticPost(w, r, "Search: "+q, "<p>No matching posts.</p>")
 		return
 	}
 	synthetic := &articlepkg.Article{}
 	synthetic.Title = "Search: " + q
 	synthetic.URL = "/search?query=" + q
-	renderGroup(w, synthetic, results)
+	renderGroup(w, r, synthetic, results)
 }
 
 func searchPosts(query string) articlepkg.Articles {
@@ -330,8 +333,8 @@ func searchPosts(query string) articlepkg.Articles {
 	return out
 }
 
-func writeSyntheticPost(w http.ResponseWriter, title, bodyHTML string) {
-	t, err := ttemplate.ParseFiles(config.C.Blog.Theme + "/post.html")
+func writeSyntheticPost(w http.ResponseWriter, r *http.Request, title, bodyHTML string) {
+	t, err := ttemplate.ParseFiles(themeFor(r) + "/post.html")
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
@@ -345,7 +348,7 @@ func writeSyntheticPost(w http.ResponseWriter, title, bodyHTML string) {
 
 func notFound(w http.ResponseWriter, r *http.Request) {
 	logs.Warn("404:", r.URL.Path)
-	t, err := ttemplate.ParseFiles(config.C.Blog.Theme + "/post.html")
+	t, err := ttemplate.ParseFiles(themeFor(r) + "/post.html")
 	if err == nil {
 		w.WriteHeader(http.StatusNotFound)
 		a := &articlepkg.Article{}
@@ -444,11 +447,11 @@ func imageHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func cssHandler(w http.ResponseWriter, r *http.Request) {
-	safeServeFile(w, r, config.C.Blog.Theme, "/css/")
+	safeServeFile(w, r, themeFor(r), "/css/")
 }
 
 func jsHandler(w http.ResponseWriter, r *http.Request) {
-	safeServeFile(w, r, config.C.Blog.Theme, "/js/")
+	safeServeFile(w, r, themeFor(r), "/js/")
 }
 
 func bingImgHandler(w http.ResponseWriter, r *http.Request) {
@@ -501,4 +504,3 @@ func bingImgHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	_, _ = io.Copy(w, imgResp.Body)
 }
-

--- a/src/server/snippets.go
+++ b/src/server/snippets.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	ttemplate "text/template"
 
 	articlepkg "github.com/sbraveyoung/gobog/src/article"
 	"github.com/sbraveyoung/gobog/src/config"
@@ -142,7 +141,7 @@ func showSnippet(w http.ResponseWriter, r *http.Request, id string) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	t, err := ttemplate.ParseFiles(themeFor(r) + "/post.html")
+	t, err := parseTextTemplate(themeFor(r) + "/post.html")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/src/server/snippets.go
+++ b/src/server/snippets.go
@@ -142,7 +142,7 @@ func showSnippet(w http.ResponseWriter, r *http.Request, id string) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	t, err := ttemplate.ParseFiles(config.C.Blog.Theme + "/post.html")
+	t, err := ttemplate.ParseFiles(themeFor(r) + "/post.html")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/src/server/theme.go
+++ b/src/server/theme.go
@@ -2,14 +2,39 @@ package server
 
 import (
 	"encoding/json"
+	"html/template"
 	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	ttemplate "text/template"
 
 	"github.com/sbraveyoung/gobog/src/config"
 )
+
+// templateFuncs is the func map every theme template gets. `add` is used by
+// the press theme's `{{printf "%02d" (add $i 2)}}` numbering; keeping the map
+// global means new themes can rely on it without server-side coordination.
+var templateFuncs = map[string]interface{}{
+	"add": func(a, b int) int { return a + b },
+	"sub": func(a, b int) int { return a - b },
+	"mul": func(a, b int) int { return a * b },
+}
+
+// parseHTMLTemplate loads a theme HTML template (html/template, used for
+// index/group pages where Go must escape interpolations).
+func parseHTMLTemplate(path string) (*template.Template, error) {
+	name := filepath.Base(path)
+	return template.New(name).Funcs(template.FuncMap(templateFuncs)).ParseFiles(path)
+}
+
+// parseTextTemplate loads a theme text template (text/template, used for
+// post.html where the body is pre-rendered HTML and must not be re-escaped).
+func parseTextTemplate(path string) (*ttemplate.Template, error) {
+	name := filepath.Base(path)
+	return ttemplate.New(name).Funcs(ttemplate.FuncMap(templateFuncs)).ParseFiles(path)
+}
 
 // themeCookie is the cookie name used to remember the visitor's theme choice
 // across requests. Its value is the bare theme directory name (e.g. "letter"),
@@ -150,7 +175,18 @@ const themeSwitcherJS = `(function () {
     injectStyle();
 
     var def = data['default'] || '';
-    var current = data.current || def;
+    var isStatic = !!data['static'];
+
+    // In static mode we live inside /__themes/<name>/... — derive the
+    // active theme from the URL prefix so the active state matches what
+    // the user actually sees, not what the manifest happens to claim.
+    var staticMatch = location.pathname.match(/^\/__themes\/([^\/]+)/);
+    var current;
+    if (isStatic) {
+      current = staticMatch ? decodeURIComponent(staticMatch[1]) : def;
+    } else {
+      current = data.current || def;
+    }
 
     var wrap = document.createElement('div');
     wrap.className = 'gobog-ts';
@@ -185,6 +221,21 @@ const themeSwitcherJS = `(function () {
       }
 
       item.addEventListener('click', function () {
+        if (isStatic) {
+          // Static export: no server to read a cookie, so navigate by URL.
+          var path = location.pathname;
+          var m = path.match(/^\/__themes\/[^\/]+(\/.*)?$/);
+          var logical = m ? (m[1] || '/') : path;
+          if (logical === '') logical = '/';
+          var target;
+          if (name === def) {
+            target = logical;
+          } else {
+            target = '/__themes/' + encodeURIComponent(name) + logical;
+          }
+          location.href = target + location.search + location.hash;
+          return;
+        }
         if (name === def) {
           clearCookie();
         } else {

--- a/src/server/theme.go
+++ b/src/server/theme.go
@@ -1,0 +1,233 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/sbraveyoung/gobog/src/config"
+)
+
+// themeCookie is the cookie name used to remember the visitor's theme choice
+// across requests. Its value is the bare theme directory name (e.g. "letter"),
+// resolved against the same parent directory as [blog].theme.
+const themeCookie = "gobog_theme"
+
+// availableThemes lists the theme directories sitting alongside the
+// configured theme. A directory only counts as a theme if it contains an
+// index.html — that's the minimum the server's renderer needs.
+func availableThemes() []string {
+	parent, current := filepath.Split(filepath.Clean(config.C.Blog.Theme))
+	parent = filepath.Clean(parent)
+	if parent == "" || parent == "." {
+		return []string{current}
+	}
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		return []string{current}
+	}
+	out := make([]string, 0, len(entries))
+	seenCurrent := false
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if _, err := os.Stat(filepath.Join(parent, name, "index.html")); err != nil {
+			continue
+		}
+		if name == current {
+			seenCurrent = true
+		}
+		out = append(out, name)
+	}
+	if !seenCurrent {
+		out = append(out, current)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// themeFor returns the filesystem path of the theme to use for this request.
+// A valid gobog_theme cookie wins; otherwise the configured theme is used.
+// The cookie value is rejected if it contains a path separator or doesn't
+// resolve to a real theme directory next to the default one.
+func themeFor(r *http.Request) string {
+	if r == nil {
+		return config.C.Blog.Theme
+	}
+	c, err := r.Cookie(themeCookie)
+	if err != nil || c.Value == "" {
+		return config.C.Blog.Theme
+	}
+	name := c.Value
+	if strings.ContainsAny(name, `/\`) || name == "." || name == ".." {
+		return config.C.Blog.Theme
+	}
+	parent, _ := filepath.Split(filepath.Clean(config.C.Blog.Theme))
+	parent = filepath.Clean(parent)
+	if parent == "" || parent == "." {
+		return config.C.Blog.Theme
+	}
+	candidate := filepath.Join(parent, name)
+	if _, err := os.Stat(filepath.Join(candidate, "index.html")); err != nil {
+		return config.C.Blog.Theme
+	}
+	return candidate
+}
+
+func themesJSONHandler(w http.ResponseWriter, r *http.Request) {
+	current := ""
+	if c, err := r.Cookie(themeCookie); err == nil {
+		current = c.Value
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"themes":  availableThemes(),
+		"current": current,
+		"default": filepath.Base(filepath.Clean(config.C.Blog.Theme)),
+	})
+}
+
+func themeSwitcherJSHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	_, _ = w.Write([]byte(themeSwitcherJS))
+}
+
+const themeSwitcherJS = `(function () {
+  if (window.__gobogThemeSwitcherLoaded) return;
+  window.__gobogThemeSwitcherLoaded = true;
+
+  var COOKIE = 'gobog_theme';
+
+  function setCookie(v) {
+    var d = new Date();
+    d.setFullYear(d.getFullYear() + 1);
+    document.cookie = COOKIE + '=' + encodeURIComponent(v) +
+      '; path=/; expires=' + d.toUTCString() + '; SameSite=Lax';
+  }
+  function clearCookie() {
+    document.cookie = COOKIE + '=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax';
+  }
+
+  function injectStyle() {
+    if (document.getElementById('gobog-theme-switcher-style')) return;
+    var s = document.createElement('style');
+    s.id = 'gobog-theme-switcher-style';
+    s.textContent = [
+      '.gobog-ts{position:fixed;right:16px;bottom:16px;z-index:99999;',
+      'font:14px/1.2 -apple-system,BlinkMacSystemFont,"Helvetica Neue",Arial,"PingFang SC","Hiragino Sans GB","Microsoft YaHei",sans-serif;}',
+      '.gobog-ts__btn{appearance:none;border:1px solid rgba(0,0,0,.15);background:#fff;color:#111;',
+      'border-radius:999px;padding:8px 14px;cursor:pointer;box-shadow:0 2px 10px rgba(0,0,0,.12);}',
+      '.gobog-ts__btn:hover{background:#f5f5f5;}',
+      '.gobog-ts__panel{position:absolute;right:0;bottom:46px;min-width:160px;background:#fff;color:#111;',
+      'border:1px solid rgba(0,0,0,.12);border-radius:10px;box-shadow:0 10px 30px rgba(0,0,0,.15);',
+      'padding:6px;display:none;max-height:60vh;overflow:auto;}',
+      '.gobog-ts--open .gobog-ts__panel{display:block;}',
+      '.gobog-ts__item{display:flex;align-items:center;justify-content:space-between;width:100%;',
+      'text-align:left;padding:8px 12px;background:transparent;border:0;border-radius:6px;',
+      'cursor:pointer;color:inherit;font:inherit;text-transform:capitalize;}',
+      '.gobog-ts__item:hover{background:rgba(0,0,0,.06);}',
+      '.gobog-ts__item--active{font-weight:600;}',
+      '.gobog-ts__check{opacity:.6;margin-left:12px;}',
+      '@media (prefers-color-scheme: dark){',
+      '.gobog-ts__btn{background:#1c1c1c;color:#eee;border-color:rgba(255,255,255,.18);box-shadow:0 2px 10px rgba(0,0,0,.5);}',
+      '.gobog-ts__btn:hover{background:#2a2a2a;}',
+      '.gobog-ts__panel{background:#1c1c1c;color:#eee;border-color:rgba(255,255,255,.14);box-shadow:0 10px 30px rgba(0,0,0,.6);}',
+      '.gobog-ts__item:hover{background:rgba(255,255,255,.08);}',
+      '}'
+    ].join('');
+    document.head.appendChild(s);
+  }
+
+  function render(data) {
+    if (!data || !Array.isArray(data.themes) || data.themes.length < 2) return;
+    injectStyle();
+
+    var def = data['default'] || '';
+    var current = data.current || def;
+
+    var wrap = document.createElement('div');
+    wrap.className = 'gobog-ts';
+
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'gobog-ts__btn';
+    btn.setAttribute('aria-haspopup', 'true');
+    btn.setAttribute('aria-expanded', 'false');
+    btn.textContent = '\u{1F3A8} 主题';
+    wrap.appendChild(btn);
+
+    var panel = document.createElement('div');
+    panel.className = 'gobog-ts__panel';
+    panel.setAttribute('role', 'menu');
+
+    data.themes.forEach(function (name) {
+      var item = document.createElement('button');
+      item.type = 'button';
+      item.className = 'gobog-ts__item' + (name === current ? ' gobog-ts__item--active' : '');
+      item.setAttribute('role', 'menuitem');
+
+      var label = document.createElement('span');
+      label.textContent = name;
+      item.appendChild(label);
+
+      if (name === current) {
+        var ck = document.createElement('span');
+        ck.className = 'gobog-ts__check';
+        ck.textContent = '✓';
+        item.appendChild(ck);
+      }
+
+      item.addEventListener('click', function () {
+        if (name === def) {
+          clearCookie();
+        } else {
+          setCookie(name);
+        }
+        location.reload();
+      });
+      panel.appendChild(item);
+    });
+
+    wrap.appendChild(panel);
+    document.body.appendChild(wrap);
+
+    function close() {
+      wrap.classList.remove('gobog-ts--open');
+      btn.setAttribute('aria-expanded', 'false');
+    }
+    btn.addEventListener('click', function (e) {
+      e.stopPropagation();
+      var open = wrap.classList.toggle('gobog-ts--open');
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    });
+    document.addEventListener('click', function (e) {
+      if (!wrap.contains(e.target)) close();
+    });
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') close();
+    });
+  }
+
+  function init() {
+    try {
+      fetch('/__themes.json', { credentials: 'same-origin' })
+        .then(function (r) { return r.ok ? r.json() : null; })
+        .then(render)
+        .catch(function () {});
+    } catch (e) { /* no fetch in ancient browsers — skip silently */ }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();
+`

--- a/src/server/theme_test.go
+++ b/src/server/theme_test.go
@@ -93,3 +93,71 @@ func TestThemeForNilRequest(t *testing.T) {
 		t.Errorf("themeFor(nil): got %q want %q", got, "themes/minimal")
 	}
 }
+
+func TestRewritePathsInHTML(t *testing.T) {
+	tests := []struct {
+		name, in, prefix, want string
+	}{
+		{
+			name:   "internal href gets prefixed",
+			in:     `<a href="/post/abc">go</a>`,
+			prefix: "/__themes/letter",
+			want:   `<a href="/__themes/letter/post/abc">go</a>`,
+		},
+		{
+			name:   "internal src gets prefixed",
+			in:     `<img src="/image/cover.png">`,
+			prefix: "/__themes/letter",
+			want:   `<img src="/__themes/letter/image/cover.png">`,
+		},
+		{
+			name:   "protocol-relative is untouched",
+			in:     `<script src="//cdn.example.com/x.js"></script>`,
+			prefix: "/__themes/letter",
+			want:   `<script src="//cdn.example.com/x.js"></script>`,
+		},
+		{
+			name:   "external URL untouched",
+			in:     `<a href="https://example.com/foo">x</a>`,
+			prefix: "/__themes/letter",
+			want:   `<a href="https://example.com/foo">x</a>`,
+		},
+		{
+			name:   "themes.json stays at root",
+			in:     `<script>fetch("/__themes.json")</script><a href="/__themes.json">m</a>`,
+			prefix: "/__themes/letter",
+			want:   `<script>fetch("/__themes.json")</script><a href="/__themes.json">m</a>`,
+		},
+		{
+			name:   "switcher script stays at root",
+			in:     `<script src="/__theme-switcher.js" defer></script>`,
+			prefix: "/__themes/letter",
+			want:   `<script src="/__theme-switcher.js" defer></script>`,
+		},
+		{
+			name:   "already-prefixed theme path is not double-prefixed",
+			in:     `<a href="/__themes/tufte/post/a">other</a>`,
+			prefix: "/__themes/letter",
+			want:   `<a href="/__themes/tufte/post/a">other</a>`,
+		},
+		{
+			name:   "form action gets prefixed",
+			in:     `<form action="/search"></form>`,
+			prefix: "/__themes/letter",
+			want:   `<form action="/__themes/letter/search"></form>`,
+		},
+		{
+			name:   "empty prefix is a no-op",
+			in:     `<a href="/post/abc">x</a>`,
+			prefix: "",
+			want:   `<a href="/post/abc">x</a>`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := rewritePathsInHTML(tc.in, tc.prefix); got != tc.want {
+				t.Errorf("rewritePathsInHTML:\n  got:  %s\n  want: %s", got, tc.want)
+			}
+		})
+	}
+}

--- a/src/server/theme_test.go
+++ b/src/server/theme_test.go
@@ -1,0 +1,95 @@
+package server
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/sbraveyoung/gobog/src/config"
+)
+
+// makeThemes creates a fake themes/ tree with the given theme names. Each
+// theme is a directory containing an empty index.html (the marker
+// availableThemes uses). Returns the path to use as config.C.Blog.Theme.
+func makeThemes(t *testing.T, names []string, current string) string {
+	t.Helper()
+	root := t.TempDir()
+	themesDir := filepath.Join(root, "themes")
+	if err := os.MkdirAll(themesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, n := range names {
+		dir := filepath.Join(themesDir, n)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("ok"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Add a stray non-theme directory and a file to make sure they're filtered.
+	_ = os.MkdirAll(filepath.Join(themesDir, "not-a-theme"), 0o755)
+	_ = os.WriteFile(filepath.Join(themesDir, "stray.txt"), []byte("x"), 0o644)
+	return filepath.Join(themesDir, current)
+}
+
+func TestAvailableThemes(t *testing.T) {
+	prev := config.C.Blog.Theme
+	defer func() { config.C.Blog.Theme = prev }()
+
+	config.C.Blog.Theme = makeThemes(t, []string{"letter", "minimal", "tufte"}, "minimal")
+	got := availableThemes()
+	sort.Strings(got)
+	want := []string{"letter", "minimal", "tufte"}
+	if len(got) != len(want) {
+		t.Fatalf("availableThemes len: got %v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("availableThemes[%d]: got %q want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestThemeFor(t *testing.T) {
+	prev := config.C.Blog.Theme
+	defer func() { config.C.Blog.Theme = prev }()
+	config.C.Blog.Theme = makeThemes(t, []string{"letter", "minimal"}, "minimal")
+	parent := filepath.Dir(config.C.Blog.Theme)
+
+	tests := []struct {
+		name   string
+		cookie string
+		want   string
+	}{
+		{"no cookie falls back to default", "", config.C.Blog.Theme},
+		{"valid theme name resolves to its dir", "letter", filepath.Join(parent, "letter")},
+		{"unknown theme falls back to default", "nope", config.C.Blog.Theme},
+		{"path traversal rejected", "../etc", config.C.Blog.Theme},
+		{"slash rejected", "letter/css", config.C.Blog.Theme},
+		{"dot rejected", ".", config.C.Blog.Theme},
+		{"empty string falls back", "", config.C.Blog.Theme},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r, _ := http.NewRequest("GET", "/", nil)
+			if tc.cookie != "" {
+				r.AddCookie(&http.Cookie{Name: themeCookie, Value: tc.cookie})
+			}
+			if got := themeFor(r); got != tc.want {
+				t.Errorf("themeFor cookie=%q: got %q want %q", tc.cookie, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestThemeForNilRequest(t *testing.T) {
+	prev := config.C.Blog.Theme
+	defer func() { config.C.Blog.Theme = prev }()
+	config.C.Blog.Theme = "themes/minimal"
+	if got := themeFor(nil); got != "themes/minimal" {
+		t.Errorf("themeFor(nil): got %q want %q", got, "themes/minimal")
+	}
+}

--- a/themes/letter/index.html
+++ b/themes/letter/index.html
@@ -90,5 +90,6 @@
   <span>© {{.Year}} {{.Site.Author}}. Built with <a href="https://github.com/sbraveyoung/gobog">gobog</a>.</span>
   <span>markdown · obsidian · go</span>
 </footer>
+<script src="/__theme-switcher.js" defer></script>
 </body>
 </html>

--- a/themes/letter/post.html
+++ b/themes/letter/post.html
@@ -83,5 +83,6 @@
   update();
 })();
 </script>
+<script src="/__theme-switcher.js" defer></script>
 </body>
 </html>

--- a/themes/minimal/group.html
+++ b/themes/minimal/group.html
@@ -80,5 +80,6 @@
 </footer>
 
 <script src="/js/site.js" defer></script>
+<script src="/__theme-switcher.js" defer></script>
 </body>
 </html>

--- a/themes/minimal/index.html
+++ b/themes/minimal/index.html
@@ -86,5 +86,6 @@
 </footer>
 
 <script src="/js/site.js" defer></script>
+<script src="/__theme-switcher.js" defer></script>
 </body>
 </html>

--- a/themes/minimal/post.html
+++ b/themes/minimal/post.html
@@ -119,5 +119,6 @@
 </footer>
 
 <script src="/js/site.js" defer></script>
+<script src="/__theme-switcher.js" defer></script>
 </body>
 </html>

--- a/themes/ocean/group.html
+++ b/themes/ocean/group.html
@@ -80,5 +80,6 @@
 </footer>
 
 <script src="/js/site.js" defer></script>
+<script src="/__theme-switcher.js" defer></script>
 </body>
 </html>

--- a/themes/ocean/index.html
+++ b/themes/ocean/index.html
@@ -86,5 +86,6 @@
 </footer>
 
 <script src="/js/site.js" defer></script>
+<script src="/__theme-switcher.js" defer></script>
 </body>
 </html>

--- a/themes/ocean/post.html
+++ b/themes/ocean/post.html
@@ -119,5 +119,6 @@
 </footer>
 
 <script src="/js/site.js" defer></script>
+<script src="/__theme-switcher.js" defer></script>
 </body>
 </html>

--- a/themes/press/index.html
+++ b/themes/press/index.html
@@ -107,5 +107,6 @@
   <span>built with <a href="https://github.com/sbraveyoung/gobog">gobog</a> · markdown · go</span>
   <span>© {{.Year}} {{.Site.Author}}</span>
 </footer>
+<script src="/__theme-switcher.js" defer></script>
 </body>
 </html>

--- a/themes/press/post.html
+++ b/themes/press/post.html
@@ -74,5 +74,6 @@
   <span>built with <a href="https://github.com/sbraveyoung/gobog">gobog</a></span>
   <span>© {{.CreateTime.Format "2006"}} {{.Site.Author}}</span>
 </footer>
+<script src="/__theme-switcher.js" defer></script>
 </body>
 </html>

--- a/themes/sepia/group.html
+++ b/themes/sepia/group.html
@@ -80,5 +80,6 @@
 </footer>
 
 <script src="/js/site.js" defer></script>
+<script src="/__theme-switcher.js" defer></script>
 </body>
 </html>

--- a/themes/sepia/index.html
+++ b/themes/sepia/index.html
@@ -86,5 +86,6 @@
 </footer>
 
 <script src="/js/site.js" defer></script>
+<script src="/__theme-switcher.js" defer></script>
 </body>
 </html>

--- a/themes/sepia/post.html
+++ b/themes/sepia/post.html
@@ -119,5 +119,6 @@
 </footer>
 
 <script src="/js/site.js" defer></script>
+<script src="/__theme-switcher.js" defer></script>
 </body>
 </html>

--- a/themes/simple/index.html
+++ b/themes/simple/index.html
@@ -92,6 +92,7 @@
             }
         })();
     </script>
+<script src="/__theme-switcher.js" defer></script>
 </body>
 
 </html>

--- a/themes/simple/login.html
+++ b/themes/simple/login.html
@@ -15,5 +15,6 @@
                 &nbsp;&nbsp;<a href="create_user">注册</a>
             </form>
         </div>
-    </body>
+        <script src="/__theme-switcher.js" defer></script>
+</body>
 </html>

--- a/themes/simple/post.html
+++ b/themes/simple/post.html
@@ -188,6 +188,7 @@
             }
         })();
     </script>
+<script src="/__theme-switcher.js" defer></script>
 </body>
 
 </html>

--- a/themes/simple/resume.html
+++ b/themes/simple/resume.html
@@ -39,7 +39,8 @@
         <div class="inner">
             {{ .Parse }}
         </div>
-    </body>
+        <script src="/__theme-switcher.js" defer></script>
+</body>
 </html>
 
 <script type="text/javascript" src="https://cdn.jsdelivr.net/gh/haoel/anti-baidu@0.6.2/js/anti-baidu-latest.min.js" charset="UTF-8"></script>

--- a/themes/tufte/index.html
+++ b/themes/tufte/index.html
@@ -83,5 +83,6 @@
   <span>© {{.Year}} {{.Site.Author}}.</span>
   <span><a href="/atom.xml">atom feed</a> · <a href="/sitemap.xml">sitemap</a></span>
 </footer>
+<script src="/__theme-switcher.js" defer></script>
 </body>
 </html>

--- a/themes/tufte/post.html
+++ b/themes/tufte/post.html
@@ -95,5 +95,6 @@
   <span>© {{.CreateTime.Format "2006"}} {{.Site.Author}}.</span>
   <span><a href="{{.Canonical}}">{{.Canonical}}</a></span>
 </footer>
+<script src="/__theme-switcher.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
This PR adds a dynamic theme switcher UI and comprehensive static export support for multiple themes. Visitors can now switch between available themes via a floating button, with their choice persisted across sessions. Static exports generate the entire site once per theme, enabling theme switching on static hosts.

## Key Changes

- **New theme switcher UI** (`src/server/theme.go`):
  - `availableThemes()`: Discovers themes by scanning for `index.html` in sibling directories
  - `themeFor()`: Resolves the active theme from cookies with path traversal protection
  - `themesJSONHandler()` and `themeSwitcherJSHandler()`: Serve theme metadata and client-side switcher script
  - Embedded JavaScript (`themeSwitcherJS`) implements a fixed-position theme picker with keyboard/click handling, supporting both server and static modes

- **Static export enhancements** (`src/server/export.go`):
  - `exportAllThemes()`: Renders the entire site once per available theme into `__themes/<name>/` subdirectories
  - `rewritePathsInHTML()` and `rewriteThemePaths()`: Rewrite absolute paths in HTML/XML to be theme-relative (e.g., `/post/abc` → `/__themes/letter/post/abc`)
  - `writeThemeManifest()`: Generates per-theme `__themes.json` manifests with static mode flag
  - Preserves root-level theme switcher endpoints (`/__themes.json`, `/__theme-switcher.js`) so the UI works offline
  - Copies theme-specific CSS/JS and shared images to each theme subdirectory

- **Template and view improvements** (`src/server/render.go`):
  - Unified template parsing via `parseHTMLTemplate()` and `parseTextTemplate()` helpers
  - Enhanced `indexView` with fields for newer themes: `Tag`, `Group`, `Articles`, `Year`, `Now`, `Feature`, `Digest`, `Rest`, `AllTags`
  - New `postCardView` wrapper exposing article properties as template fields (`.Pinned`, `.AI`, `.CoverURL`, etc.)
  - `flattenPosts()`: Flattens hierarchical article groups into a sorted feed for flat-layout themes
  - Added `Year` field to `articleView` for template compatibility

- **Server routing** (`src/server/server.go`):
  - Registered `/__themes.json` and `/__theme-switcher.js` endpoints
  - Updated handlers to use `themeFor(r)` to respect user's theme choice
  - Updated `renderGroup()` signature to accept `*http.Request` for theme resolution

- **Theme template updates**:
  - Added `<script src="/__theme-switcher.js" defer></script>` to all theme templates (minimal, ocean, sepia, letter, tufte, press, simple)
  - Ensures the switcher UI loads on every page

## Notable Implementation Details

- **Security**: Cookie values are validated against path traversal (`/`, `\`, `.`, `..`) and must resolve to an actual theme directory
- **Backward compatibility**: Older themes continue working; new themes can rely on the expanded `indexView` and `postCardView` fields
- **Static mode detection**: The JavaScript detects static exports via URL pattern matching (`/__themes/<name>/...`) and navigates by URL instead of cookies
- **Path rewriting**: Intelligently preserves theme-switching endpoints and already-prefixed theme paths to avoid double-prefixing
- **Comprehensive test coverage**: `src/server/theme_test.go` validates theme discovery, cookie handling, and path rewriting logic

https://claude.ai/code/session_01UazC5oqirBEJDRatWaSCiE