### PR TITLE
themes(minimal): wire pagefind search on the home page; refresh ARCHI…

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5,23 +5,26 @@ the rough edges still are. Updated whenever the layout changes.
 
 ```
 ┌─ Obsidian vault (local) ────────┐    ┌─ sbraveyoung/blog ─────────────┐
-│  Blog/                          │    │  source/                       │
-│    post/                        │    │    post/                       │
-│    pages/                       │ ◄──┤    pages/                      │
-│    resource/image/              │    │    resource/image/             │
+│  Blog/                          │    │  .                             │
+│    post/                        │    │  ├─ post/                      │
+│    pages/                       │ ◄──┤  ├─ pages/                     │
+│    resource/image/              │    │  └─ resource/image/            │
 │  ┌────────────────────────────┐ │    └────────────────┬───────────────┘
 │  │ gobog-obsidian plugin       │ │                    │
 │  │   • pull / push markdown    │ │                    │ push to master
 │  │   • auto front-matter       │ ├──►                 │ → repository_dispatch
 │  │   • WeChat draft (optional) │ │                    │   (event=blog-update)
-│  └────────────────────────────┘ │                    ▼
-└─────────────────────────────────┘    ┌─ sbraveyoung/sbraveyoung.github.io ┐
-                                       │  .github/workflows/deploy.yml:     │
-                                       │    1. checkout blog + gobog        │
-                                       │    2. go build _gobog/src          │
+│  │   • deploy status echo      │ │                    ▼
+│  └────────────────────────────┘ │    ┌─ sbraveyoung/sbraveyoung.github.io ┐
+└─────────────────────────────────┘    │  .github/workflows/deploy.yml:     │
+                                       │    1. checkout blog + gobog (pin)  │
+                                       │    2. go build _gobog/src (cached) │
                                        │    3. gobog -export _dist          │
-                                       │    4. cp _dist → working tree      │
-                                       │    5. commit + push                │
+                                       │    4. pagefind --site _dist        │
+                                       │    5. cp _dist → working tree      │
+                                       │    6. commit + push                │
+                                       │  .github/workflows/linkcheck.yml:  │
+                                       │    weekly external-link sweep      │
                                        │  _gobog.json controls theme +      │
                                        │  comments + brand                  │
                                        └────────────────────────────────────┘
@@ -58,20 +61,26 @@ overwrites the working tree.
 
 ## Improvements still worth doing
 
-1. **No client-side search on the static export.** Server mode has
-   `/search`; static mode doesn't (would need a JS lunr or pagefind
-   index emitted at build time). Punt for now — the blog isn't huge.
+1. ~~**No client-side search on the static export.**~~ **Done.** The
+   github.io deploy runs `pagefind --site _dist` after rendering and
+   `themes/minimal/index.html` pulls in the bundled UI on the home
+   page. Other themes (sepia, ocean, letter, press, tufte) haven't
+   been wired up — copy the `<link>` / `<script>` block from minimal
+   when you adopt one.
 2. **Atom feed item count is unbounded.** `buildAtomFeed` lists every
    post. With many years of writing this becomes a several-MB feed.
    Cap at e.g. 50 newest.
-3. **Image dedupe.** The legacy `<source>/image/` and the canonical
-   `<source>/resource/image/` are both copied to `<dist>/image/`. If
-   the same basename exists in both, the second overwrites the first.
-   In practice we only have one of them populated at a time; still
-   worth a guardrail.
-4. **No automated link checker.** Posts with `[]()` markdown links to
-   external sites can rot silently. A nightly workflow that runs a
-   simple HTTP HEAD across the export would catch them.
+3. ~~**Image dedupe.**~~ **Guardrail in place.** The github.io deploy
+   warns via `::warning::` when the same image basename exists in both
+   `_blog/image/` (legacy) and `_blog/resource/image/` (canonical).
+   The collision itself still silently overwrites — fixing it
+   structurally means picking one canonical home and removing the
+   other in the source.
+4. ~~**No automated link checker.**~~ **Done.** Weekly
+   `.github/workflows/linkcheck.yml` in github.io scans every external
+   `http(s)://` in the rendered HTML and surfaces 4xx/5xx/timeout as
+   workflow annotations (non-fatal by default; manual dispatch with
+   `fatal=true` for stricter runs).
 5. **WeChat IP whitelist friction.** Every machine the plugin runs from
    needs that egress IP whitelisted in the MP console. A tiny relay
    service on a VPS with a fixed IP would avoid that — but adds an
@@ -79,15 +88,19 @@ overwrites the working tree.
 6. **gobog dependency on beego logger.** Pulls in a fairly large
    transitive dep tree just for logging. Could be replaced with
    `log/slog` from the standard library. Cosmetic.
-7. **No preview-before-deploy on github.io.** The workflow renders
-   straight to main. For a one-author blog this is fine; for a team a
-   PR-preview workflow that publishes to a branch would help.
-8. **`cert/` in the blog repo.** Holds TLS keys for the legacy
-   self-hosted era. They aren't deployed anywhere by the current
-   pipeline, but they sit in the repo's history. Consider rotating
-   the certs out of git (move to a vault / 1Password) before the next
-   major commit. Treat anything currently in `cert/` as compromised
-   for hygiene.
+7. **Partial PR preview.** sbraveyoung/blog now has a
+   `.github/workflows/preview.yml` that dry-renders the site for every
+   PR and surfaces dead-link / orphan-resource warnings as annotations.
+   Still missing: a published preview URL (would require pushing to a
+   `gh-pages/<pr>` branch or an artifact deploy). Live with the
+   annotations until that's worth building.
+8. **GH_PAT single point of failure.** The deploy depends on a Fine-
+   grained PAT tied to one user account. Expires / revoked / suspended
+   → deploys break silently. See `docs/AUTH.md` in the github.io repo
+   for the GitHub App migration path; do it when (a) you start using
+   AI-coding agents that need a bot identity, (b) you want per-repo
+   audit logs, or (c) you don't want deploys to break the day you
+   take a sabbatical.
 
 ## Dead-link audit (one-time)
 
@@ -107,6 +120,9 @@ Done as part of the current refresh:
 Re-run periodically with:
 
 ```sh
-grep -rln "github\.com/SmartBrave" source/post
-grep -rln "file:///" source/post
+grep -rln "github\.com/SmartBrave" post
+grep -rln "file:///" post
 ```
+
+(Source paths are at the repo root now — `post/`, `pages/`,
+`resource/image/`. The historical `source/` prefix is gone.)

--- a/themes/minimal/index.html
+++ b/themes/minimal/index.html
@@ -8,6 +8,10 @@
 <link rel="icon" href="/css/favicon.svg" type="image/svg+xml">
 <link rel="alternate" type="application/atom+xml" href="/atom.xml" title="Atom feed">
 <link rel="stylesheet" href="/css/main.css">
+<!-- pagefind UI styles; 404s harmlessly when no index has been built
+     (e.g. local preview). The github.io deploy runs `pagefind --site
+     _dist` after rendering, which populates /_pagefind/. -->
+<link rel="stylesheet" href="/_pagefind/pagefind-ui.css">
 <script>
 // Resolve theme before paint to avoid the dark-mode flash.
 (function () {
@@ -52,6 +56,12 @@
   <section class="hero">
     <h1>{{ .Site.Title }}</h1>
     <p class="hero-sub">{{ .Site.Subtitle }}</p>
+    <!-- Search bar. pagefind UI mounts here when /_pagefind/ is
+         present; the init script below bails silently otherwise, leaving
+         the div empty (and naturally collapsed). data-pagefind-ignore
+         keeps the indexer from indexing its own placeholder strings on
+         a re-run. -->
+    <div id="site-search" class="hero-search" data-pagefind-ignore></div>
   </section>
 
   <section class="post-list">
@@ -87,5 +97,22 @@
 
 <script src="/js/site.js" defer></script>
 <script src="/__theme-switcher.js" defer></script>
+<!-- pagefind UI bootstrap. The script tag 404s silently when no index
+     was built; in that case nothing else fires. When it loads, the
+     onload hook mounts a search box into #site-search. -->
+<script src="/_pagefind/pagefind-ui.js" onload="
+  if (typeof PagefindUI === 'undefined') return;
+  new PagefindUI({
+    element: '#site-search',
+    showSubResults: true,
+    showImages: false,
+    pageSize: 6,
+    translations: {
+      placeholder: '搜索文章…',
+      zero_results: '没找到 &quot;[SEARCH_TERM]&quot; 相关的内容',
+      load_more: '加载更多',
+    },
+  });
+"></script>
 </body>
 </html>


### PR DESCRIPTION
…TECTURE

themes/minimal/index.html:
- Add <link rel="stylesheet" href="/_pagefind/pagefind-ui.css"> in head (404s harmlessly without an index — e.g. local preview).
- Add #site-search div in the hero, marked data-pagefind-ignore so the indexer doesn't index its own placeholder strings on re-runs.
- Add /_pagefind/pagefind-ui.js with onload bootstrap that instantiates PagefindUI when present and stays silent when the script 404s (theme is forward-compatible with builds that don't run pagefind).

The github.io deploy workflow runs `pagefind --site _dist` after rendering, so /_pagefind/ exists in production. Other themes (sepia, ocean, letter, press, tufte) haven't been wired up — copy the three adds from minimal when adopting one.

ARCHITECTURE.md:
- Diagram: drop the stale source/ prefix in the blog repo column (PR #3 in blog flattened the layout); add the new pagefind + linkcheck steps to the github.io column; add "deploy status echo" to the plugin bullets (lands in a follow-up commit on gobog-obsidian).
- Improvements list: mark #1 (search), #3 (image dedupe), #4 (link checker), #7 (PR preview) as done or partially done with pointers to the workflows that implement them. Repoint #8 from cert/ (gone after PR #3) to the GH_PAT single-point-of-failure; link to AUTH.md.
- Dead-link audit grep commands: drop the source/ prefix.

https://claude.ai/code/session_01UiLm5CSC9cEDGopYrkccox